### PR TITLE
Drop ineffective cleanup commands

### DIFF
--- a/org.gnome.Decibels.json
+++ b/org.gnome.Decibels.json
@@ -19,17 +19,6 @@
         "--socket=pulseaudio",
         "--env=GJS_DISABLE_JIT=1"
     ],
-    "cleanup": [
-        "/include",
-        "/lib/pkgconfig",
-        "/man",
-        "/share/doc",
-        "/share/gtk-doc",
-        "/share/man",
-        "/share/pkgconfig",
-        "*.la",
-        "*.a"
-    ],
     "modules": [
         {
             "name": "decibels",


### PR DESCRIPTION
They are unnecessary because no files are affected by these commands.